### PR TITLE
Drag and drop for tasks and stories

### DIFF
--- a/src/js/components/board.js
+++ b/src/js/components/board.js
@@ -253,6 +253,9 @@ board = (function(){
                 _storyObjMap[storyData._id].handleEdit(storyData);
             }
         },
+        requestStoryStatusCodeChange: function(storyId, newStatusCode) {
+            _storyObjMap[storyId].requestStoryStatusCodeChange(newStatusCode);
+        },
         handleMoveStory: function(storyId, newStatusCode) {
             _storyObjMap[storyId].handleMove(newStatusCode);
         },

--- a/src/js/components/board.js
+++ b/src/js/components/board.js
@@ -265,6 +265,9 @@ board = (function(){
         handleEditTask: function(storyId, taskData) {
              _storyObjMap[storyId].handleEditTask(taskData);
         },
+        requestTaskStatusCodeChange: function(storyId, taskId, newStatusCode) {
+            _storyObjMap[storyId].requestTaskStatusCodeChange(taskId, newStatusCode);
+        },
         handleMoveTask: function(storyId, taskId, newStatusCode) {
             _storyObjMap[storyId].handleMoveTask(taskId, newStatusCode);
         },

--- a/src/js/components/story.js
+++ b/src/js/components/story.js
@@ -7,6 +7,12 @@ var story = function() {
     var _storiesSection;
     var _columnNames;
 
+    function handleTaskDrop(statusCode, draggable, ui) {
+        var taskId = ui.helper.attr("data-taskId");
+        board.requestTaskStatusCodeChange(_storyJson._id, taskId, statusCode);
+        return true;
+    }
+
     function render() {
         _storyRow = $('<div>').addClass('row story').attr('data-story', _index);
 
@@ -17,6 +23,10 @@ var story = function() {
         var cols = [];
         for(var i = 0; i < _columnNames.length; i++) {
             var newColumn = $('<div>').addClass('progresscol').attr('data-column', i).appendTo(_storyRow);
+            newColumn.droppable({
+                accept: '.task',
+                drop: curry(handleTaskDrop)(i)
+            });
             newColumn.width($(headerCols[i + 1]).width() + 1);
             if(i == _columnNames.length - 1) {
                 newColumn.addClass('done-col');
@@ -285,6 +295,9 @@ var story = function() {
         },
         handleEditTask: function(taskData) {
             _taskObjMap[taskData._id].handleEdit(taskData);
+        },
+        requestTaskStatusCodeChange: function(taskId, newStatusCode) {
+            _taskObjMap[taskId].requestStatusCodeChange(newStatusCode);
         },
         handleMoveTask: function(taskId, newStatusCode) {
             _taskObjMap[taskId].handleMove(newStatusCode);

--- a/src/js/components/story.js
+++ b/src/js/components/story.js
@@ -16,54 +16,22 @@ var story = function() {
         }
         if (droppedSticky.hasClass("story-descr")){ // Sticky is a story
             board.requestStoryStatusCodeChange(stickyStoryId, statusCode);
-            return true;
         } else { // Sticky is a task
             if (statusCode === STORY_COLUMN) { // Cannot drop a task into the story column
                 return false;
             }
             var stickyTaskId = droppedSticky.attr("data-taskId");
             board.requestTaskStatusCodeChange(stickyStoryId, stickyTaskId, statusCode);
-            return true;
         }
+        return true;
     }
 
-    function render() {
-        _storyRow = $('<div>').addClass('row story').attr('data-story', _index);
-
-        var headerCols = $('#boardHeader>.progresscol'); 
-
-        var storyColumn = $('<div>').addClass('progresscol').attr('data-column', STORY_COLUMN).appendTo(_storyRow);
-        storyColumn.droppable({
-            accept: '.task',
-            drop: curry(handleStickyDrop)(STORY_COLUMN)
-        });
-        storyColumn.width($(headerCols[0]).width() + 1);
-
-        var cols = [];
-        for(var i = 0; i < _columnNames.length; i++) {
-            var newColumn = $('<div>').addClass('progresscol').attr('data-column', i).appendTo(_storyRow);
-            newColumn.droppable({
-                accept: '.task',
-                drop: curry(handleStickyDrop)(i)
-            });
-            newColumn.width($(headerCols[i + 1]).width() + 1);
-            if(i == _columnNames.length - 1) {
-                newColumn.addClass('done-col');
-            }
-            cols.push(newColumn);
-        }
-
-        //attempt at droppable
-        // var dropScope = "story_" + _index;
-        // for(var i = 0; i < cols.length;i++) {
-        //     console.log('make droppable' + cols[i]);
-        //     cols[i].droppable({scope: dropScope});
-        // }
-
+    function renderStorySticky() {
         _storySticky = $("<div>").addClass('task story-descr');
         _storySticky.attr("data-storyId", _storyJson._id);
         _storySticky.draggable({
-            revert: "invalid"
+            revert: true,
+            handle: ".taskcenter"
         });
 
         var colSelector = "." + 'progresscol[data-column=' + _storyJson.statusCode + ']';
@@ -93,13 +61,42 @@ var story = function() {
         );
 
 
-        var addTaskButton = $('<button>').text('Add task').addClass('btn btn-default addTaskButton').appendTo(storyColumn);
+        var addTaskButton = $('<button>').text('Add task').addClass('btn btn-default addTaskButton');
         addTaskButton.addClass('show-on-hover');
         addTaskButton.css('display', 'none');
         addTaskButton.appendTo(_storySticky);
 
 
         addTaskButton.click(addTaskToStory);
+    }
+
+    function render() {
+        _storyRow = $('<div>').addClass('row story').attr('data-story', _index);
+
+        var headerCols = $('#boardHeader>.progresscol'); 
+
+        var storyColumn = $('<div>').addClass('progresscol').attr('data-column', STORY_COLUMN).appendTo(_storyRow);
+        storyColumn.droppable({
+            accept: '.task',
+            drop: curry(handleStickyDrop)(STORY_COLUMN)
+        });
+        storyColumn.width($(headerCols[0]).width() + 1);
+
+        var cols = [];
+        for(var i = 0; i < _columnNames.length; i++) {
+            var newColumn = $('<div>').addClass('progresscol').attr('data-column', i).appendTo(_storyRow);
+            newColumn.droppable({
+                accept: '.task',
+                drop: curry(handleStickyDrop)(i)
+            });
+            newColumn.width($(headerCols[i + 1]).width() + 1);
+            if(i == _columnNames.length - 1) {
+                newColumn.addClass('done-col');
+            }
+            cols.push(newColumn);
+        }
+
+        renderStorySticky();
 
         var allTasks = _storyJson.tasks;
         _taskObjMap = {};
@@ -294,20 +291,8 @@ var story = function() {
         },
         handleMove: function(newStatusCode) {
             _storyJson.statusCode = newStatusCode;
-
-            var leftPanelDO = _storySticky.children('.task-panels').children('.taskpanel')[0];
-            var rightPanelDO = _storySticky.children('.task-panels').children('.taskpanel')[2];
-
-            _storyRow.remove('.story-descr');
-
-            leftPanelDO.innerHTML = "";
-            rightPanelDO.innerHTML = "";
-
-            leftPanelInit($(leftPanelDO));
-            rightPanelInit($(rightPanelDO));
-
-            var colSelector = "." + 'progresscol[data-column=' + _storyJson.statusCode + ']';
-            _storyRow.children(colSelector).append(_storySticky);
+            $(_storyRow).find(".story-descr").remove()
+            renderStorySticky();
         },
         handleAddTask: function(taskData) {
             var taskObj = task();

--- a/src/js/components/story.js
+++ b/src/js/components/story.js
@@ -7,8 +7,12 @@ var story = function() {
     var _storiesSection;
     var _columnNames;
 
-    function handleTaskDrop(statusCode, draggable, ui) {
+    function handleTaskDrop(statusCode, ignored_draggable, ui) {
         var taskId = ui.helper.attr("data-taskId");
+        var storyId = ui.helper.attr("data-storyId");
+        if (storyId !== _storyJson._id) {
+            return false;
+        }
         board.requestTaskStatusCodeChange(_storyJson._id, taskId, statusCode);
         return true;
     }

--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -40,7 +40,8 @@ var task = function() {
 		});
 
 		_taskDiv.draggable({
-			revert: true
+			revert: true,
+			handle: ".taskcenter"
 		});
 
 		_taskDiv.attr("data-taskId", _taskJson._id);

--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -39,6 +39,12 @@ var task = function() {
 			drop: handlePersonDrop
 		});
 
+		_taskDiv.draggable({
+			revert: true
+		});
+
+		_taskDiv.attr("data-taskId", _taskJson._id);
+
 		_taskDiv.hover(
 			//Hover in
 			function() {
@@ -295,6 +301,9 @@ var task = function() {
 			middlePanel.text(_taskJson.name);
 			middlePanelInit(middlePanel);
 		},
+		/** Asks the server to move (change the status code) the task **/
+		requestStatusCodeChange: updateStatusCode,
+		/** Moves the task UI (called in response to the server) */
 		handleMove: function(newStatusCode) {
 			_taskJson.statusCode = newStatusCode;
 			_taskDiv.remove();

--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -44,6 +44,7 @@ var task = function() {
 		});
 
 		_taskDiv.attr("data-taskId", _taskJson._id);
+		_taskDiv.attr("data-storyId", _storyId);
 
 		_taskDiv.hover(
 			//Hover in

--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -248,6 +248,9 @@ var task = function() {
 	}
 
 	function editTask() {
+		if (_taskDiv.hasClass("ui-draggable-dragging")) {
+			return;
+		}
 		editTaskModal.open(_taskJson, function(newTaskJson) {
 			$.ajax({
                 type: 'PUT',

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -34,8 +34,8 @@ function customAjax(method, url, data, successCallback, failCallback) {
 	});
 }
 
-// Borrowed from Kevin Ennis (http://kevvv.in/currying-in-javascript/)
-// Permission pending [email sent]
+// Author: Kevin Ennis (http://kevvv.in/currying-in-javascript/)
+// Used with permission
 function curry( fn ) {
 	var arity = fn.length;
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -33,3 +33,19 @@ function customAjax(method, url, data, successCallback, failCallback) {
 	    console.log(data);
 	});
 }
+
+// Borrowed from Kevin Ennis (http://kevvv.in/currying-in-javascript/)
+// Permission pending [email sent]
+function curry( fn ) {
+	var arity = fn.length;
+
+	return (function resolver() {
+		var memory = Array.prototype.slice.call( arguments );
+		return function() {
+			var local = memory.slice(), next;
+			Array.prototype.push.apply( local, arguments );
+			next = local.length >= arity ? fn : resolver;
+			return next.apply( null, local );
+		};
+	}());
+}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -368,6 +368,12 @@ body {
 	.story-descr {
 		height: 125px;
 	}
+
+	.task.ui-draggable-dragging {
+		.editCover, .arrow, .delete {
+			display: none;
+		}
+	}
 }
 
 #editModal {
@@ -391,4 +397,8 @@ body {
 			cursor: pointer;
 		}
 	}
+}
+
+.ui-draggable-dragging {
+	z-index: 10;
 }

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -370,8 +370,10 @@ body {
 	}
 
 	.task.ui-draggable-dragging {
-		.editCover, .arrow, .delete {
-			display: none;
+		.show-on-hover {
+			// It looks like something is setting an inline style and overriding this, so we have to make it important
+			// so that the clickables don't get triggered on drags
+			display: none !important;
 		}
 	}
 }


### PR DESCRIPTION
Implemented drag and drop for tasks and stories.

- Added data-taskId, and data-storyId to task divs
- Added data-storyId to story divs
- Created requestTaskStatusCodeChange, requestStoryStatusCodeChange on board, story, and task objects to fire off an AJAX request to move the stories.
- Added CSS to hide show-on-hover elements when a task/story is being dragged.
- Added a check to editTask to check if it's currently being dragged, and if so, to not trigger the modal.
- Refactored story render to extract a renderStorySticky method, so we can re-render just the sticky when the story moves.
- Smaller changes

Will resolve issue #1