### PR TITLE
Updated the tooltips to use JQuery UI Tooltips

### DIFF
--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -32,6 +32,16 @@ var task = function() {
 		setDefaultSize(leftPanel, middlePanel, rightPanel, peopleRow);
 		makeResizable(leftPanel, middlePanel, rightPanel, peopleRow);
 
+		if (_taskJson.notes !== "") {
+			middlePanel.tooltip({
+				items: "div",
+				content: function() { return ("Notes:\n" + escapeHtml(_taskJson.notes)).replace(/\n/g, "<br />")},
+				position: {
+					my: "center top+15", at: "center bottom", of: middlePanel
+				},
+				show: { delay: 500 }
+			});
+		}
 
 		_taskDiv.droppable({
 			accept: '.person',
@@ -51,7 +61,6 @@ var task = function() {
 			function() {
 				$(_taskDiv).find('.hide-on-hover').hide();
 				$(_taskDiv).find('.show-on-hover').show();
-				$(_taskDiv).attr('title', "Notes:\n" + _taskJson.notes);
 			},
 			//Hover out
 			function() {

--- a/src/js/components/task.js
+++ b/src/js/components/task.js
@@ -39,7 +39,7 @@ var task = function() {
 				position: {
 					my: "center top+15", at: "center bottom", of: middlePanel
 				},
-				show: { delay: 500 }
+				show: { delay: 1000 }
 			});
 		}
 
@@ -50,7 +50,9 @@ var task = function() {
 
 		_taskDiv.draggable({
 			revert: true,
-			handle: ".taskcenter"
+			handle: ".taskcenter",
+			start: function() {if (_taskJson.notes !== "") {middlePanel.tooltip("disable")}},
+			stop: function() {if (_taskJson.notes !== "") {middlePanel.tooltip("enable")}}
 		});
 
 		_taskDiv.attr("data-taskId", _taskJson._id);
@@ -259,6 +261,11 @@ var task = function() {
 	function editTask() {
 		if (_taskDiv.hasClass("ui-draggable-dragging")) {
 			return;
+		}
+		if (_taskJson.notes !== "") {
+			// We can't programmatically close the tooltip, because it wasn't opened programmatically.
+			// We can disable and then immediately enable it though, which has the same effect.
+			_taskDiv.find(".taskcenter").tooltip("disable").tooltip("enable");
 		}
 		editTaskModal.open(_taskJson, function(newTaskJson) {
 			$.ajax({

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -33,3 +33,15 @@ function customAjax(method, url, data, successCallback, failCallback) {
 	    console.log(data);
 	});
 }
+
+function escapeHtml(text) {
+	var map = {
+		'&': '&amp;',
+		'<': '&lt;',
+		'>': '&gt;',
+		'"': '&quot;',
+		"'": '&#039;'
+	};
+
+	return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+}

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -430,4 +430,5 @@ body {
 	box-shadow: $shadow;
 	background-color: $post-yellow;
 	border-radius: 10px;
+	z-index: 900 !important;
 }

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -424,3 +424,10 @@ body {
 .ui-draggable-dragging {
 	z-index: 10;
 }
+
+.ui-tooltip {
+	border: 1px solid #444444;
+	box-shadow: $shadow;
+	background-color: $post-yellow;
+	border-radius: 10px;
+}


### PR DESCRIPTION
Kevin | Zilboard | Story 2 - As a Suzanne I would like note tooltip fixes because my team likes long notes on our tasks.

 - Modified the tooltips to use JQuery UI tooltips instead of browser native tooltips (title element).
 - Because the JQuery tooltips can contain HTML, I had to add a escapeHTML method to the utils.

Items for review:
 - The tooltip is set to appear after a delay of 1 s. That can be easily customized
 - Because the task isn't re-rendered when the "notes" value changes, we have to use a function to get the tooltip content
   - It would be better if we could pre-compute the content, but that would require the render function to be called every time the task json changes. I believe this is out of scope?
 - The css/style - it looks alright to me but maybe you have a different opinion?

